### PR TITLE
Make getAccessToken async

### DIFF
--- a/src/LiveKitAVClient.ts
+++ b/src/LiveKitAVClient.ts
@@ -185,7 +185,7 @@ export default class LiveKitAVClient extends AVClient {
     }
 
     // Get an access token
-    const accessToken = this._liveKitClient.getAccessToken(
+    const accessToken = await this._liveKitClient.getAccessToken(
       connectionSettings.username, // The LiveKit API Key
       connectionSettings.password, // The LiveKit Secret Key
       this.room,

--- a/src/LiveKitAVClient.ts
+++ b/src/LiveKitAVClient.ts
@@ -138,7 +138,7 @@ export default class LiveKitAVClient extends AVClient {
     if (
       getGame().user?.isGM &&
       (connectionSettings.url === "" ||
-        connectionSettings.url === "" ||
+        connectionSettings.username === "" ||
         connectionSettings.password === "")
     ) {
       this.master.config.render(true);

--- a/src/LiveKitClient.ts
+++ b/src/LiveKitClient.ts
@@ -370,13 +370,13 @@ export default class LiveKitClient {
    * @param userName Display name of the FVTT user
    * @param metadata User metadata, including the FVTT User ID
    */
-  getAccessToken(
+  async getAccessToken(
     apiKey: string,
     secretKey: string,
     roomName: string,
     userName: string,
     metadata: string
-  ): string {
+  ): Promise<string> {
     // Set ths signing options
     const signOpts: jwt.SignOptions = {
       issuer: apiKey, // The configured API Key


### PR DESCRIPTION
As discussed on Discord, making the `getAccessToken` method async is a good first step in having external authentication service support in the module.
This is of course just a temporary/proof-of-concept solution to having registered authentication providers.