### PR TITLE
Re-add hooks for "LiveKit client is available" and "LiveKit client is initialized"

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ export default tseslint.config(
   {
     rules: {
       "no-console": ["warn"],
+      "@typescript-eslint/no-namespace": "off",
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
-    "@league-of-foundry-developers/foundry-vtt-types": "github:League-of-Foundry-Developers/foundry-vtt-types#main",
+    "fvtt-types": "github:League-of-Foundry-Developers/foundry-vtt-types#main",
     "@pixi/assets": "github:foundry-vtt-types/pixi-assets#main",
     "@pixi/compressed-textures": "github:foundry-vtt-types/pixi-compressed-textures#main",
     "@pixi/core": "github:foundry-vtt-types/pixi-core#main",

--- a/src/LiveKitAVClient.ts
+++ b/src/LiveKitAVClient.ts
@@ -14,7 +14,7 @@ import { callWhenReady, delayReload } from "./utils/helpers";
 import { LiveKitConnectionSettings } from "../types/avclient-livekit";
 import LiveKitAVConfig from "./LiveKitAVConfig";
 import { Logger } from "./utils/logger";
-import { DeepPartial } from "@league-of-foundry-developers/foundry-vtt-types/utils";
+import { DeepPartial } from "fvtt-types/utils";
 
 const log = new Logger();
 

--- a/src/LiveKitAVClient.ts
+++ b/src/LiveKitAVClient.ts
@@ -16,6 +16,24 @@ import LiveKitAVConfig from "./LiveKitAVConfig";
 import { Logger } from "./utils/logger";
 import { DeepPartial } from "fvtt-types/utils";
 
+/**
+ * Establish types that are called in the LiveKitAVClient.
+ */
+declare module "fvtt-types/configuration" {
+  namespace Hooks {
+    interface HookConfig {
+      /**
+       * The LiveKit client is available, but not yet initialized.
+       */
+      liveKitClientAvailable: (client: LiveKitClient) => void;
+      /**
+       * The LiveKit client is available and initialized. It's ready for use.
+       */
+      liveKitClientInitialized: (client: LiveKitClient) => void;
+    }
+  }
+}
+
 const log = new Logger();
 
 if (import.meta.hot) {

--- a/src/LiveKitAVConfig.ts
+++ b/src/LiveKitAVConfig.ts
@@ -1,4 +1,4 @@
-import { DeepPartial } from "@league-of-foundry-developers/foundry-vtt-types/utils";
+import { DeepPartial } from "fvtt-types/utils";
 import { LANG_NAME, MODULE_NAME } from "./utils/constants";
 import { delayReload } from "./utils/helpers";
 import { Logger } from "./utils/logger.js";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,9 @@
     "skipLibCheck": true,
 
     // Include FVTT Types
-    "types": ["@league-of-foundry-developers/foundry-vtt-types"],
-
+    "types": [
+      "fvtt-types"
+    ],
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
## Intent

This changeset's primary aim is to re-implement the hooks that seem to have been lost in the v12 -> v13 refactor. Without these hooks, the Forge (and other services that may like to offer their own connection data with a module) can't insert its LiveKit connection data.

As a side effect, per the community type library team's suggestion, I renamed the type library in `package.json` and updated its name wherever it's referenced in the rest of the code.

### What's left?
- This will likely still need some manual testing. For the Forge's part, this still needs tested on our side.

### Notes
- I don't have `pnpm` and only noticed the lockfile after I reinstalled the type library. Any chance someone else might be willing to update the lockfile? :sweat_smile: